### PR TITLE
VertxSliceServer.start() returns port the server started to listen on

### DIFF
--- a/src/main/java/com/artipie/vertx/VertxSliceServer.java
+++ b/src/main/java/com/artipie/vertx/VertxSliceServer.java
@@ -98,12 +98,15 @@ public final class VertxSliceServer implements Closeable {
 
     /**
      * Start the server.
+     *
+     * @return Port the server is listening on.
      */
-    public void start() {
+    public int start() {
         synchronized (this.sync) {
             this.server = this.vertx.createHttpServer();
             this.server.requestHandler(this.proxyHandler());
             this.server.rxListen(this.port).blockingGet();
+            return this.server.actualPort();
         }
     }
 

--- a/src/main/java/com/artipie/vertx/VertxSliceServer.java
+++ b/src/main/java/com/artipie/vertx/VertxSliceServer.java
@@ -76,6 +76,16 @@ public final class VertxSliceServer implements Closeable {
     /**
      * Ctor.
      *
+     * @param vertx The vertx.
+     * @param served The slice to be served.
+     */
+    public VertxSliceServer(final Vertx vertx, final Slice served) {
+        this(vertx, served, 0);
+    }
+
+    /**
+     * Ctor.
+     *
      * @param served The slice to be served.
      * @param port The port.
      */

--- a/src/test/java/com/artipie/vertx/VertxSliceServerTest.java
+++ b/src/test/java/com/artipie/vertx/VertxSliceServerTest.java
@@ -198,8 +198,7 @@ public final class VertxSliceServerTest {
     public void serverMayStartOnRandomPort() {
         final VertxSliceServer srv = new VertxSliceServer(
             this.vertx,
-            (line, headers, body) -> connection -> connection.accept(RsStatus.OK, headers, body),
-            0
+            (line, headers, body) -> connection -> connection.accept(RsStatus.OK, headers, body)
         );
         MatcherAssert.assertThat(srv.start(), new IsNot<>(new IsEqual<>(0)));
     }

--- a/src/test/java/com/artipie/vertx/VertxSliceServerTest.java
+++ b/src/test/java/com/artipie/vertx/VertxSliceServerTest.java
@@ -44,6 +44,7 @@ import org.hamcrest.Matchers;
 import org.hamcrest.TypeSafeMatcher;
 import org.hamcrest.core.AllOf;
 import org.hamcrest.core.IsEqual;
+import org.hamcrest.core.IsNot;
 import org.hamcrest.core.StringContains;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -191,6 +192,16 @@ public final class VertxSliceServerTest {
             this.port, VertxSliceServerTest.HOST, ""
         ).rxSend().blockingGet();
         MatcherAssert.assertThat(response, new IsErrorResponse(exception));
+    }
+
+    @Test
+    public void serverMayStartOnRandomPort() {
+        final VertxSliceServer srv = new VertxSliceServer(
+            this.vertx,
+            (line, headers, body) -> connection -> connection.accept(RsStatus.OK, headers, body),
+            0
+        );
+        MatcherAssert.assertThat(srv.start(), new IsNot<>(new IsEqual<>(0)));
     }
 
     private void start(final Slice slice) {


### PR DESCRIPTION
Closes issue #11 
VertxSliceServer may start on random port if `0` value is passed as port argument and will return actual port it listens on as result to call of start() method. Useful in tests