### PR TITLE
Prohibit starting VertxSliceServer more than once

### DIFF
--- a/src/main/java/com/artipie/vertx/VertxSliceServer.java
+++ b/src/main/java/com/artipie/vertx/VertxSliceServer.java
@@ -113,6 +113,9 @@ public final class VertxSliceServer implements Closeable {
      */
     public int start() {
         synchronized (this.sync) {
+            if (this.server != null) {
+                throw new IllegalStateException("Server was already started");
+            }
             this.server = this.vertx.createHttpServer();
             this.server.requestHandler(this.proxyHandler());
             this.server.rxListen(this.port).blockingGet();

--- a/src/test/java/com/artipie/vertx/VertxSliceServerTest.java
+++ b/src/test/java/com/artipie/vertx/VertxSliceServerTest.java
@@ -48,6 +48,7 @@ import org.hamcrest.core.IsEqual;
 import org.hamcrest.core.IsNot;
 import org.hamcrest.core.StringContains;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -56,6 +57,7 @@ import org.junit.jupiter.api.Test;
  *
  * @since 0.1
  */
+@SuppressWarnings("PMD.TooManyMethods")
 public final class VertxSliceServerTest {
 
     /**
@@ -210,6 +212,16 @@ public final class VertxSliceServerTest {
                     connection.accept(RsStatus.OK, new Headers.From(headers), body)
         );
         MatcherAssert.assertThat(srv.start(), new IsNot<>(new IsEqual<>(0)));
+    }
+
+    @Test
+    void repeatedServerStartTest() {
+        this.start(
+            (s, iterable, publisher) -> {
+                throw new IllegalStateException("Request serving is not expected in this test");
+            }
+        );
+        Assertions.assertThrows(IllegalStateException.class, this.server::start);
     }
 
     private void start(final Slice slice) {

--- a/src/test/java/com/artipie/vertx/VertxSliceServerTest.java
+++ b/src/test/java/com/artipie/vertx/VertxSliceServerTest.java
@@ -221,7 +221,11 @@ public final class VertxSliceServerTest {
                 throw new IllegalStateException("Request serving is not expected in this test");
             }
         );
-        Assertions.assertThrows(IllegalStateException.class, this.server::start);
+        final IllegalStateException err = Assertions.assertThrows(
+            IllegalStateException.class,
+            this.server::start
+        );
+        Assertions.assertEquals("Server was already started", err.getMessage());
     }
 
     private void start(final Slice slice) {


### PR DESCRIPTION
Currently it is possible to call VertxSliceServer.start multiple times for a single server instance. It leads to confusing behavior of a VertxSliceServer.stop method which stops only one vertx server instance leaving other running. It looks like prohibiting starting a server more than once can make things simpler.