### PR TITLE
Return 100-continue response before accepting the body if expected

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ target/
 .idea/
 *.iml
 .DS_Store
+.project
+.settings/**

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@ SOFTWARE.
     <dependency>
       <groupId>com.artipie</groupId>
       <artifactId>http</artifactId>
-      <version>0.8.2</version>
+      <version>0.15.3</version>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
@@ -91,10 +91,6 @@ SOFTWARE.
     <dependency>
       <groupId>com.jcabi</groupId>
       <artifactId>jcabi-log</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.artipie</groupId>
-      <artifactId>asto</artifactId>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/src/main/java/com/artipie/vertx/ContinueConnection.java
+++ b/src/main/java/com/artipie/vertx/ContinueConnection.java
@@ -1,0 +1,76 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 artipie.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.vertx;
+
+import com.artipie.http.Connection;
+import com.artipie.http.Headers;
+import com.artipie.http.rs.RsStatus;
+import io.vertx.reactivex.core.http.HttpServerResponse;
+import java.nio.ByteBuffer;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import org.reactivestreams.Publisher;
+
+/**
+ * Connection which supports {@code 100 Continue} status code responses.
+ * <p>
+ * It sends continue status to client and then delegates other work to origin connection.
+ * </p>
+ * @since 0.2
+ */
+final class ContinueConnection implements Connection {
+
+    /**
+     * Vertx response output.
+     */
+    private final HttpServerResponse response;
+
+    /**
+     * Origin HTTP connection.
+     */
+    private final Connection origin;
+
+    /**
+     * Wraps origin connection with continue responses support.
+     * @param response Vertx response output
+     * @param origin Origin connection
+     */
+    ContinueConnection(final HttpServerResponse response, final Connection origin) {
+        this.response = response;
+        this.origin = origin;
+    }
+
+    @Override
+    public CompletionStage<Void> accept(final RsStatus status, final Headers headers,
+        final Publisher<ByteBuffer> body) {
+        final CompletionStage<Void> res;
+        if (status == RsStatus.CONTINUE) {
+            this.response.writeContinue();
+            res = CompletableFuture.completedFuture(null);
+        } else {
+            res = this.origin.accept(status, headers, body);
+        }
+        return res;
+    }
+}

--- a/src/main/java/com/artipie/vertx/VertxConnection.java
+++ b/src/main/java/com/artipie/vertx/VertxConnection.java
@@ -1,0 +1,85 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 artipie.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.vertx;
+
+import com.artipie.http.Connection;
+import com.artipie.http.Headers;
+import com.artipie.http.rs.RsStatus;
+import io.reactivex.Flowable;
+import io.vertx.reactivex.core.buffer.Buffer;
+import io.vertx.reactivex.core.http.HttpServerResponse;
+import java.nio.ByteBuffer;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import org.reactivestreams.Publisher;
+
+/**
+ * Vertx connection accepts Artipie response and send it to {@link HttpServerResponse}.
+ * @since 0.2
+ */
+final class VertxConnection implements Connection {
+
+    /**
+     * Vertx server response output.
+     */
+    private final HttpServerResponse rsp;
+
+    /**
+     * New connection for response.
+     * @param rsp Response output
+     */
+    VertxConnection(final HttpServerResponse rsp) {
+        this.rsp = rsp;
+    }
+
+    @Override
+    public CompletionStage<Void> accept(final RsStatus status,
+        final Headers headers, final Publisher<ByteBuffer> body) {
+        final int code = Integer.parseInt(status.code());
+        this.rsp.setStatusCode(code);
+        for (final Map.Entry<String, String> header : headers) {
+            this.rsp.putHeader(header.getKey(), header.getValue());
+        }
+        this.rsp.setChunked(true);
+        final CompletableFuture<HttpServerResponse> promise = new CompletableFuture<>();
+        Flowable.fromPublisher(body)
+            .map(VertxConnection::mapBuffer)
+            .doOnComplete(() -> promise.complete(this.rsp))
+            .doOnError(promise::completeExceptionally)
+            .subscribe(this.rsp.toSubscriber());
+        return promise.thenCompose(ignored -> CompletableFuture.allOf());
+    }
+
+    /**
+     * Map {@link ByteBuffer} to {@link Buffer}.
+     * @param buffer Java byte buffer
+     * @return Vertx buffer
+     */
+    private static Buffer mapBuffer(final ByteBuffer buffer) {
+        final byte[] bytes = new byte[buffer.remaining()];
+        buffer.get(bytes);
+        return Buffer.buffer(bytes);
+    }
+}

--- a/src/main/java/com/artipie/vertx/VertxSliceServer.java
+++ b/src/main/java/com/artipie/vertx/VertxSliceServer.java
@@ -165,6 +165,9 @@ public final class VertxSliceServer implements Closeable {
      * @return Completion of request serving.
      */
     private CompletionStage<Void> serve(final HttpServerRequest req) {
+        if (expectContinue(req)) {
+            req.response().writeContinue();
+        }
         return this.served.response(
             new RequestLine(req.rawMethod(), req.uri(), req.version().toString()).toString(),
             req.headers(),
@@ -204,5 +207,15 @@ public final class VertxSliceServer implements Closeable {
         body.append(throwable.toString()).append("\n");
         throwable.printStackTrace(new PrintWriter(body));
         response.end(body.toString());
+    }
+
+    /**
+     * Check if request expects continue response to be sent before body.
+     * @param req HTTP request
+     * @return True if expects continue
+     */
+    private static boolean expectContinue(final HttpServerRequest req) {
+        final String hdr = req.headers().get("expect");
+        return hdr != null && hdr.equalsIgnoreCase("100-continue");
     }
 }

--- a/src/main/java/com/artipie/vertx/VertxSliceServer.java
+++ b/src/main/java/com/artipie/vertx/VertxSliceServer.java
@@ -25,10 +25,8 @@ package com.artipie.vertx;
 
 import com.artipie.http.Slice;
 import com.artipie.http.rq.RequestLine;
-import io.reactivex.Flowable;
 import io.vertx.core.Handler;
 import io.vertx.reactivex.core.Vertx;
-import io.vertx.reactivex.core.buffer.Buffer;
 import io.vertx.reactivex.core.http.HttpServer;
 import io.vertx.reactivex.core.http.HttpServerRequest;
 import io.vertx.reactivex.core.http.HttpServerResponse;
@@ -37,8 +35,6 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.net.HttpURLConnection;
 import java.nio.ByteBuffer;
-import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 /**
@@ -165,34 +161,12 @@ public final class VertxSliceServer implements Closeable {
      * @return Completion of request serving.
      */
     private CompletionStage<Void> serve(final HttpServerRequest req) {
-        if (expectContinue(req)) {
-            req.response().writeContinue();
-        }
+        final HttpServerResponse response = req.response();
         return this.served.response(
             new RequestLine(req.rawMethod(), req.uri(), req.version().toString()).toString(),
             req.headers(),
             req.toFlowable().map(buffer -> ByteBuffer.wrap(buffer.getBytes()))
-        ).send(
-            (status, headers, body) -> {
-                final int code = Integer.parseInt(status.code());
-                final HttpServerResponse response = req.response().setStatusCode(code);
-                for (final Map.Entry<String, String> header : headers) {
-                    response.putHeader(header.getKey(), header.getValue());
-                }
-                response.setChunked(true);
-                final CompletableFuture<HttpServerResponse> promise = new CompletableFuture<>();
-                Flowable.fromPublisher(body).map(
-                    buf -> {
-                        final byte[] bytes = new byte[buf.remaining()];
-                        buf.get(bytes);
-                        return Buffer.buffer(bytes);
-                    })
-                    .doOnComplete(() -> promise.complete(response))
-                    .doOnError(promise::completeExceptionally)
-                    .subscribe(response.toSubscriber());
-                return promise.thenCompose(ignored -> CompletableFuture.allOf());
-            }
-        );
+        ).send(new ContinueConnection(response, new VertxConnection(response)));
     }
 
     /**
@@ -207,15 +181,5 @@ public final class VertxSliceServer implements Closeable {
         body.append(throwable.toString()).append("\n");
         throwable.printStackTrace(new PrintWriter(body));
         response.end(body.toString());
-    }
-
-    /**
-     * Check if request expects continue response to be sent before body.
-     * @param req HTTP request
-     * @return True if expects continue
-     */
-    private static boolean expectContinue(final HttpServerRequest req) {
-        final String hdr = req.headers().get("expect");
-        return hdr != null && hdr.equalsIgnoreCase("100-continue");
     }
 }


### PR DESCRIPTION
artipie/artipie#382 - send `100 Continue` response status before accepting request body if `Expect: 100-continue` header found.