### PR TITLE
feat: HttpServer starts with HttpServerOptions

### DIFF
--- a/src/main/java/com/artipie/vertx/VertxSliceServer.java
+++ b/src/main/java/com/artipie/vertx/VertxSliceServer.java
@@ -26,6 +26,7 @@ package com.artipie.vertx;
 import com.artipie.http.Slice;
 import com.artipie.http.rq.RequestLine;
 import io.vertx.core.Handler;
+import io.vertx.core.http.HttpServerOptions;
 import io.vertx.reactivex.core.Vertx;
 import io.vertx.reactivex.core.http.HttpServer;
 import io.vertx.reactivex.core.http.HttpServerRequest;
@@ -55,9 +56,9 @@ public final class VertxSliceServer implements Closeable {
     private final Slice served;
 
     /**
-     * The port to start server on.
+     * Represents options used by an HttpServer instance.
      */
-    private final Integer port;
+    private final HttpServerOptions options;
 
     /**
      * The Http server.
@@ -76,7 +77,7 @@ public final class VertxSliceServer implements Closeable {
      * @param served The slice to be served.
      */
     public VertxSliceServer(final Vertx vertx, final Slice served) {
-        this(vertx, served, 0);
+        this(vertx, served, new HttpServerOptions().setPort(0));
     }
 
     /**
@@ -86,19 +87,39 @@ public final class VertxSliceServer implements Closeable {
      * @param port The port.
      */
     public VertxSliceServer(final Slice served, final Integer port) {
-        this(Vertx.vertx(), served, port);
+        this(Vertx.vertx(), served, new HttpServerOptions().setPort(port));
     }
 
     /**
      * Ctor.
+     *
      * @param vertx The vertx.
      * @param served The slice to be served.
      * @param port The port.
      */
-    public VertxSliceServer(final Vertx vertx, final Slice served, final Integer port) {
+    public VertxSliceServer(
+        final Vertx vertx,
+        final Slice served,
+        final Integer port
+    ) {
+        this(vertx, served, new HttpServerOptions().setPort(port));
+    }
+
+    /**
+     * Ctor.
+     *
+     * @param vertx The vertx.
+     * @param served The slice to be served.
+     * @param options The options to use.
+     */
+    public VertxSliceServer(
+        final Vertx vertx,
+        final Slice served,
+        final HttpServerOptions options
+    ) {
         this.vertx = vertx;
         this.served = served;
-        this.port = port;
+        this.options = options;
         this.sync = new Object();
     }
 
@@ -112,9 +133,9 @@ public final class VertxSliceServer implements Closeable {
             if (this.server != null) {
                 throw new IllegalStateException("Server was already started");
             }
-            this.server = this.vertx.createHttpServer();
+            this.server = this.vertx.createHttpServer(this.options);
             this.server.requestHandler(this.proxyHandler());
-            this.server.rxListen(this.port).blockingGet();
+            this.server.rxListen().blockingGet();
             return this.server.actualPort();
         }
     }

--- a/src/test/java/com/artipie/vertx/VertxSliceServerTest.java
+++ b/src/test/java/com/artipie/vertx/VertxSliceServerTest.java
@@ -248,7 +248,7 @@ public final class VertxSliceServerTest {
 
     @Test
     public void serverStartsWithHttpServerOptions() {
-        final int expected = 88;
+        final int expected = 81;
         final VertxSliceServer srv = new VertxSliceServer(
             this.vertx,
             (line, headers, body) ->

--- a/src/test/java/com/artipie/vertx/VertxSliceServerTest.java
+++ b/src/test/java/com/artipie/vertx/VertxSliceServerTest.java
@@ -28,6 +28,7 @@ import com.artipie.http.Slice;
 import com.artipie.http.rs.RsStatus;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.reactivex.Flowable;
+import io.vertx.core.http.HttpServerOptions;
 import io.vertx.reactivex.core.Vertx;
 import io.vertx.reactivex.core.buffer.Buffer;
 import io.vertx.reactivex.ext.web.client.HttpResponse;
@@ -243,6 +244,23 @@ public final class VertxSliceServerTest {
                     connection.accept(RsStatus.OK, new Headers.From(headers), body)
         );
         MatcherAssert.assertThat(srv.start(), new IsNot<>(new IsEqual<>(0)));
+    }
+
+    @Test
+    public void serverStartsWithHttpServerOptions() {
+        final int expected = 88;
+        final VertxSliceServer srv = new VertxSliceServer(
+            this.vertx,
+            (line, headers, body) ->
+                connection ->
+                    connection.accept(
+                        RsStatus.OK,
+                        new Headers.From(headers),
+                        body
+                    ),
+            new HttpServerOptions().setPort(expected)
+        );
+        MatcherAssert.assertThat(srv.start(), new IsEqual<>(expected));
     }
 
     @Test

--- a/src/test/java/com/artipie/vertx/VertxSliceServerTest.java
+++ b/src/test/java/com/artipie/vertx/VertxSliceServerTest.java
@@ -28,6 +28,7 @@ import com.artipie.http.Slice;
 import com.artipie.http.rs.RsStatus;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.reactivex.Flowable;
+import io.vertx.core.http.HttpServerOptions;
 import io.vertx.reactivex.core.Vertx;
 import io.vertx.reactivex.core.buffer.Buffer;
 import io.vertx.reactivex.ext.web.client.HttpResponse;
@@ -243,6 +244,23 @@ public final class VertxSliceServerTest {
                     connection.accept(RsStatus.OK, new Headers.From(headers), body)
         );
         MatcherAssert.assertThat(srv.start(), new IsNot<>(new IsEqual<>(0)));
+    }
+
+    @Test
+    public void serverStartsWithHttpServerOptions() throws Exception {
+        final int expected = this.rndPort();
+        final VertxSliceServer srv = new VertxSliceServer(
+            this.vertx,
+            (line, headers, body) ->
+                connection ->
+                    connection.accept(
+                        RsStatus.OK,
+                        new Headers.From(headers),
+                        body
+                    ),
+            new HttpServerOptions().setPort(expected)
+        );
+        MatcherAssert.assertThat(srv.start(), new IsEqual<>(expected));
     }
 
     @Test

--- a/src/test/java/com/artipie/vertx/VertxSliceServerTest.java
+++ b/src/test/java/com/artipie/vertx/VertxSliceServerTest.java
@@ -247,23 +247,6 @@ public final class VertxSliceServerTest {
     }
 
     @Test
-    public void serverStartsWithHttpServerOptions() {
-        final int expected = 81;
-        final VertxSliceServer srv = new VertxSliceServer(
-            this.vertx,
-            (line, headers, body) ->
-                connection ->
-                    connection.accept(
-                        RsStatus.OK,
-                        new Headers.From(headers),
-                        body
-                    ),
-            new HttpServerOptions().setPort(expected)
-        );
-        MatcherAssert.assertThat(srv.start(), new IsEqual<>(expected));
-    }
-
-    @Test
     void repeatedServerStartTest() {
         this.start(
             (s, iterable, publisher) -> {

--- a/src/test/java/com/artipie/vertx/VertxSliceServerTest.java
+++ b/src/test/java/com/artipie/vertx/VertxSliceServerTest.java
@@ -28,7 +28,6 @@ import com.artipie.http.Slice;
 import com.artipie.http.rs.RsStatus;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.reactivex.Flowable;
-import io.vertx.core.http.HttpServerOptions;
 import io.vertx.reactivex.core.Vertx;
 import io.vertx.reactivex.core.buffer.Buffer;
 import io.vertx.reactivex.ext.web.client.HttpResponse;


### PR DESCRIPTION
Close: #29 

- added full constructor to `VertxSliceServer` that accepts `HttpServerOptions`, these options used to create `HttpServer`
- added a test that checks using `HttpServerOptions`.